### PR TITLE
Add osx build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@
 language: objective-c
 
 env:
+  matrix:
+    
+    - CONDA_PY=27
+    - CONDA_PY=34
+    - CONDA_PY=35
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "gXlExo4QgjrdwHSnCfNPe7PChYunxCn6w4TlD+TSotKbtACgXBVDMy6KDe2beL25Jl/EuZ6AKTsQ01WtuffD7rKIMP4LaWhqS8mTcqIrMij1P4wkSuSqKS+GksS4s1eKx1RmaS2moA5RJuOshz2Hp7oTlE+fGVxAfbqqpB/YNNtzAgkzV9CZwiYgY1rN3jeZkLT60HBR8U3fX+tkoMZj6tmpiXEUVd2cwY9SF95/3mxZaTxjgFBBMPIeCyf6Gx4egbWzfXkZxkIhbQs8edEbKGJpSmcLe/bz1FYi3+TmF8IHlGYxUf4oKLnMBZpW6RhxYMLEbGpiCHMUhc4K4wit0Krk8223bhBimd7UI8VAUzPwGFR99vqGphPhGeqCYGE7py8pIZFSL+7vAa1LpsNCdFQjdm9L8M+uPXzR3N4a8ljw7MxqP0ecwl9aUbsB1vRxNRxFdslPi7rwWpYidP5KHsLibO0GhTc7qmNv1nIa/n5wAbcwK64TRego/Tjlyu3+PRVrMeq0EPViDWxGvjsSk03rGyGE4+0LX55+o1wtkgFCc8AGfz3oWvT8BFGKHvmtapgYZtp5h19z6lskqoh7VC8hzMQlHrIVXxp7MMOXp8Oe7VoxE/n6vgfTzkYBiDlUXRQ2BzWmG7zmgBYq169WfvY2E3dHARN96nk0i0vMMAw="

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Terminology
 
 Current build status
 ====================
+
 Linux: [![Circle CI](https://circleci.com/gh/conda-forge/bob-feedstock.svg?style=svg)](https://circleci.com/gh/conda-forge/bob-feedstock)
 OSX: [![TravisCI](https://travis-ci.org/conda-forge/bob-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/bob-feedstock) 
 Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/bob-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/bob-feedstock/branch/master)

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -29,7 +29,7 @@ cat << EOF | docker run -i \
                         -v ${RECIPE_ROOT}:/recipe_root \
                         -v ${FEEDSTOCK_ROOT}:/feedstock_root \
                         -a stdin -a stdout -a stderr \
-                        pelson/obvious-ci:latest_x64 \
+                        condaforge/linux-anvil \
                         bash || exit $?
 
 export BINSTAR_TOKEN=${BINSTAR_TOKEN}
@@ -40,7 +40,7 @@ echo "$config" > ~/.condarc
 conda clean --lock
 
 conda update --yes --all
-conda install --yes conda-build==1.18.2
+conda install --yes conda-build
 conda info
 
 # Embarking on 3 case(s).

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,7 @@ dependencies:
   # Note, we used to use the naive caching of docker images, but found that it was quicker
   # just to pull each time. #rollondockercaching
   override:
-    - docker pull pelson/obvious-ci:latest_x64
-#    - docker pull pelson/conda32_obvious_ci
+    - docker pull condaforge/linux-anvil
 
 test:
   override:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: true  # [not linux]
+  skip: true  # [win]
   script: python -B setup.py install --single-version-externally-managed --record record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,6 +96,7 @@ test:
   requires:
     - nose
     - cmake
+    - pkg-config
 
 about:
   home: http://idiap.github.io/bob/


### PR DESCRIPTION
Error:  Packages missing in current osx-64 channels: 
- bob.ap ==2.0.4
- bob.db.atnt ==2.0.3
- bob.db.base ==2.0.6
- bob.db.iris ==2.0.4
- bob.db.mnist ==2.0.3
- bob.db.verification.utils ==2.0.7
- bob.db.wine ==2.0.3
- bob.io.audio ==2.0.0
- bob.io.image ==2.0.6
- bob.io.video ==2.0.6
- bob.ip.base ==2.0.9
- bob.ip.color ==2.0.4
- bob.ip.draw ==2.0.3
- bob.ip.facedetect ==2.0.7
- bob.ip.gabor ==2.0.5
- bob.ip.optflow.hornschunck ==2.0.6
- bob.ip.optflow.liu ==2.0.5
- bob.learn.activation ==2.0.4
- bob.learn.boosting ==2.0.7
- bob.learn.em ==2.0.8
- bob.learn.libsvm ==2.0.3
- bob.learn.linear ==2.0.7
- bob.learn.mlp ==2.0.11
- bob.measure ==2.1.1
- bob.sp ==2.0.4
